### PR TITLE
Reapply fonts when Sober updates

### DIFF
--- a/fonts.py
+++ b/fonts.py
@@ -1,13 +1,113 @@
 # fonts are complicated as shit bro
+# fr
 
+from genericpath import exists
 from pathlib import Path
 import shutil
 import zipfile
+import sys
+import hashlib
 
 SOBER_APP_ID = "org.vinegarhq.Sober"
 SOBER_BASE = Path.home() / ".var/app" / SOBER_APP_ID / "data/sober"
 APK_DIR = SOBER_BASE / "packages/x86_64/com.roblox.client"
 OVERLAY_FONT_DIR = SOBER_BASE / "asset_overlay/content/fonts"
+
+CONFIG_BASE = Path(getattr(sys, "_MEIPASS", Path(__file__).parent))
+CONFIG_FILE = CONFIG_BASE / "ui.md"
+
+INSTALLED_FONTS_DIR = Path.home() / ".local" / "share" / "Lution" / "installed_font"
+
+def _calculate_sha256_checksum(apk_path: Path):
+    with open(apk_path, "rb") as f:
+        return hashlib.file_digest(f, "sha256").hexdigest()
+
+
+def _needs_update() -> bool:
+    apk_path = _find_apk()
+
+    if apk_path == None: return False
+
+    last_sober_apk_checksum = ""
+
+    for raw_line in Path(CONFIG_FILE).read_text().splitlines():
+        line = raw_line.strip()
+
+        if not line.startswith("LastAPKChecksum = "): continue
+
+        last_sober_apk_checksum = line[len("LastAPKChecksum = "):].strip()
+
+    if last_sober_apk_checksum == "":
+        return False
+    else:
+        hash = hashlib.sha256()
+
+        with open(apk_path, "rb"):
+            hash = _calculate_sha256_checksum(apk_path)
+
+            return hash != last_sober_apk_checksum
+
+
+def _update_apk_checksum():
+    apk_path = _find_apk()
+
+    if apk_path == None: return
+
+    hash = _calculate_sha256_checksum(apk_path)
+
+    checksum_location = None
+    whole_config = Path(CONFIG_FILE).read_text().splitlines()
+
+    for i, raw_line in enumerate(whole_config):
+        line = raw_line.strip()
+
+        if not line.startswith("LastAPKChecksum = "): continue
+
+        checksum_location = i
+
+    if checksum_location != None:
+        with open(CONFIG_FILE, "w") as f:
+            whole_config[checksum_location] = f"LastAPKChecksum = {hash}"
+            _ = f.write("\n".join(whole_config))
+
+        return
+
+    with open(CONFIG_FILE, "a") as f:
+        _ = f.write(f"\n# Fonts\nLastAPKChecksum = {hash}")
+
+def save_installed_font(font_path: Path | str) -> None:
+    if isinstance(font_path, str):
+        font_path = Path.from_uri("file:"+font_path)
+
+    if not INSTALLED_FONTS_DIR.exists():
+        INSTALLED_FONTS_DIR.mkdir(exist_ok=True, parents=True)
+
+    dest_file = INSTALLED_FONTS_DIR / ("font"+font_path.suffix)
+    try:
+        _ = shutil.copy(font_path, dest_file, follow_symlinks=True)
+    except shutil.SameFileError:
+        return
+
+    _update_apk_checksum()
+
+def apply_font_updates():
+    if not _needs_update(): return
+
+    if not INSTALLED_FONTS_DIR.exists(): return
+
+    candidates = sorted(INSTALLED_FONTS_DIR.glob("*"), key=lambda p: p.stat().st_ctime)
+    if not candidates: return
+    target_font = candidates[0]
+
+    try:
+        apply_font(str(target_font))
+        _update_apk_checksum()
+        print("Succesfully updated fonts!")
+    except FileNotFoundError:
+        print("Could not update fonts :(")
+        return
+
+
 
 
 def _find_apk():

--- a/main.py
+++ b/main.py
@@ -506,6 +506,8 @@ class Lution(tk.Tk):
 # fonts
 
     def build_fontpicker(self, parent, pad):
+        fonts.apply_font_updates()
+
         tk.Label(parent, text="Font file (.ttf / .otf)", bg=parent["bg"],
                  fg=FG, font=BODY_FONT).pack(anchor="w", padx=pad, pady=(0, 2))
 
@@ -544,6 +546,7 @@ class Lution(tk.Tk):
                 return
             try:
                 replaced = fonts.apply_font(source)
+                fonts.save_installed_font(source)
             except FileNotFoundError as e:
                 status.configure(text=str(e), fg=ERROR)
                 return
@@ -570,7 +573,7 @@ class Lution(tk.Tk):
                           ).pack(anchor="w", padx=pad, pady=(0, 6))
 
         tk.Label(parent,
-                 text=("NOTE: You have to reapply the font when you update Sober"),
+                 text=("NOTE: If Sober updates and removes your font, reopen Lution and we'll reapply it automatically"),
                  bg=parent["bg"], fg=FG_DIM, font=("TkDefaultFont", 10),
                  anchor="w", wraplength=500, justify="left"
                  ).pack(anchor="w", padx=pad, pady=(0, 14))

--- a/ui.md
+++ b/ui.md
@@ -23,6 +23,3 @@ ModManager
 # About
 Subtitle = Lution developed by WookHQ (https://github.com/wookhq)
 Image = cat.png | look at this cat bro
-
-# Fonts
-LastAPKChecksum = 88e538e7d7de282b7a20c910ede753be5d55e56df3d5230f61f1e8b41fc46361

--- a/ui.md
+++ b/ui.md
@@ -23,3 +23,6 @@ ModManager
 # About
 Subtitle = Lution developed by WookHQ (https://github.com/wookhq)
 Image = cat.png | look at this cat bro
+
+# Fonts
+LastAPKChecksum = 88e538e7d7de282b7a20c910ede753be5d55e56df3d5230f61f1e8b41fc46361


### PR DESCRIPTION
Instead of asking the user to manually input the font again, the applied font and the Sober APK SHA256 checksum get saved, then every time Lution opens we compare the saved checksum with the current checksum, and if they do not match we reapply fonts with the saved font